### PR TITLE
Add port to jail.local

### DIFF
--- a/Fail2Ban/README.md
+++ b/Fail2Ban/README.md
@@ -45,6 +45,7 @@ enabled = true
 logpath = %(nginx_access_log)s
 filter = nginxrepeatoffender
 banaction = nginxrepeatoffender
+port = http,https
 bantime  = 86400   ; 1 day
 findtime = 604800   ; 1 week
 maxretry = 20

--- a/Fail2Ban/jail.local
+++ b/Fail2Ban/jail.local
@@ -2,6 +2,7 @@
 [nginxrepeatoffender]
 enabled = true
 logpath = %(nginx_access_log)s
+port = http,https
 filter = nginxrepeatoffender
 banaction = nginxrepeatoffender
 bantime  = 86400   ; 1 day


### PR DESCRIPTION
Default actions require port to be specified:

```
#
# Action shortcuts. To be used to define action parameter

# The simplest action to take: ban only
action_ = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]

# ban & send an e-mail with whois report to the destemail.
action_mw = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
              %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s", protocol="%(protocol)s", chain="%(chain)s", sendername="%(sendername)s"]

# ban & send an e-mail with whois report and relevant log lines
# to the destemail.
action_mwl = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
               %(mta)s-whois-lines[name=%(__name__)s, dest="%(destemail)s", logpath=%(logpath)s, chain="%(chain)s", sendername="%(sendername)s"]

# Choose default action.  To change, just override value of 'action' with the
# interpolation to the chosen action shortcut (e.g.  action_mw, action_mwl, etc) in jail.local
# globally (section [DEFAULT]) or per specific section
action = %(action_mwl)s
```