### PR TITLE
Added Bash Script for Auto Updating via Cron

### DIFF
--- a/VERSION_2/README.md
+++ b/VERSION_2/README.md
@@ -9,7 +9,7 @@ Nginx Bad Bot Blocker
 
 #[* - Configuration and Updating Instructions](#configuration-instructions-for-the-nginx-badbot-blocker)
 
-Over 4500 (and growing) Nginx rules to block bad bots.
+Over 4000 (and growing) Nginx rules to block bad bots.
 
 Bad bots are defined as:
 
@@ -45,7 +45,7 @@ Copy the contents of **/conf.d/blacklist.conf** into your /etc/nginx/conf.d fold
 
 `cd /etc/nginx/conf.d`
 
-`sudo wget https://raw.githubusercontent.com/mariusv/nginx-badbot-blocker/master/conf.d/blacklist.conf`
+`sudo wget https://github.com/mariusv/nginx-badbot-blocker/raw/master/VERSION_2/conf.d/blacklist.conf`
 
 ##2: 
 
@@ -59,12 +59,12 @@ Copy the contents of **/conf.d/blacklist.conf** into your /etc/nginx/conf.d fold
 
 - copy the blockbots.conf file into that folder
 
-`sudo wget https://raw.githubusercontent.com/mariusv/nginx-badbot-blocker/master/bots.d/blockbots.conf`
+`sudo wget https://github.com/mariusv/nginx-badbot-blocker/raw/master/VERSION_2/bots.d/blockbots.conf`
 
 
 - copy the ddos.conf file into the same folder
 
-`sudo wget https://raw.githubusercontent.com/mariusv/nginx-badbot-blocker/master/bots.d/ddos.conf`
+`sudo wget https://github.com/mariusv/nginx-badbot-blocker/raw/master/VERSION_2/bots.d/ddos.conf`
 
 ##3:
 
@@ -76,12 +76,12 @@ Whitelist all your own domain names and IP addresses. **Please note important ch
 
 - copy the whitelist-ips.conf file into that folder
 
-`sudo wget https://raw.githubusercontent.com/mariusv/nginx-badbot-blocker/master/bots.d/whitelist-ips.conf`
+`sudo wget https://github.com/mariusv/nginx-badbot-blocker/raw/master/VERSION_2/bots.d/whitelist-domains.conf`
 
 
 - copy the whitelist-domains.conf file into the same folder
 
-`sudo wget https://raw.githubusercontent.com/mariusv/nginx-badbot-blocker/master/bots.d/whitelist-domains.conf`
+`sudo wget https://github.com/mariusv/nginx-badbot-blocker/raw/master/VERSION_2/bots.d/whitelist-ips.conf`
 
 Use nano, vim or any other text editor to edit both whitelist-ips.conf and whitelist-domains.conf to include all your own domain names and IP addresses that you want to specifically whitelist from the blocker script. 
 
@@ -173,7 +173,7 @@ Updating to the latest version is now as simple as:
 
 `cd /etc/nginx/conf.d`
 
-`sudo wget https://raw.githubusercontent.com/mariusv/nginx-badbot-blocker/master/conf.d/blacklist.conf`
+`sudo wget https://github.com/mariusv/nginx-badbot-blocker/blob/master/VERSION_2/conf.d/blacklist.conf`
 
 `sudo nginx -t`
 
@@ -183,9 +183,9 @@ And you will be up to date with all your whitelisted domains included automatica
 
 # AUTO UPDATING:
 
-See my latest auto updater bash script at:
+See the latest auto updater bash script at:
 
-https://raw.githubusercontent.com/mariusv/nginx-ultimate-bad-bot-blocker/master/updatenginxblocker.sh
+https://raw.githubusercontent.com/mariusv/nginx-badbot-blocker/master/VERSION_2/updatenginxblocker.sh
 
 This can now be run as a daily cron to keep you up to date without having to remember to do it yourself. I have this cron running on 3 nginx servers for the past week pulling their updates automatically from my master, works flawlessly.
 

--- a/VERSION_2/README.md
+++ b/VERSION_2/README.md
@@ -181,6 +181,14 @@ Updating to the latest version is now as simple as:
 
 And you will be up to date with all your whitelisted domains included automatically for you now. 
 
+# AUTO UPDATING:
+
+See my latest auto updater bash script at:
+
+https://raw.githubusercontent.com/mariusv/nginx-ultimate-bad-bot-blocker/master/updatenginxblocker.sh
+
+This can now be run as a daily cron to keep you up to date without having to remember to do it yourself. I have this cron running on 3 nginx servers for the past week pulling their updates automatically from my master, works flawlessly.
+
 Relax now and sleep better at night knowing your site is telling all those baddies to go away !!!
 
 

--- a/VERSION_2/updatenginxblocker.sh
+++ b/VERSION_2/updatenginxblocker.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Bash Script for Auto Updating the Nginx Bad Bot Blocker
+# Copyright - https://github.com/mitchellkrogza
+# Project Url: https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker
+
+# MAKE SURE you have your whitelist-ips.conf and whitelist-domains.conf files in /etc/nginx/bots.d
+# A major change to using include files was introduced in
+# https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/commit/c7acdfa8228d2f19a83e5bb14d54355db86fcebf
+
+# PLEASE READ UPDATED CONFIGURATION INSTRUCTIONS BEFORE USING THIS
+
+# Save this file as /bin/updatenginxblocker.sh
+# Make it Executable chmod +x /bin/updatenginxblocker.sh
+
+# RUN THE UPDATE
+# Here our script runs, pulls the latest update, reloads nginx and emails you a notification
+# Place your own valid email address where it says "me@myemail.com"
+ 
+cd /etc/nginx/conf.d
+sudo wget https://raw.githubusercontent.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/master/conf.d/globalblacklist.conf -O globalblacklist.conf
+sudo service nginx reload | mail -s "Nginx Bad Bot Blocker Updated" me@myemail.com
+exit 0
+
+# Add this as a cron to run daily / weekly as you like
+# Here's a sample CRON entry to update every day at 10pm
+# 00 22 * * * /bin/updatenginxblocker.sh

--- a/VERSION_2/updatenginxblocker.sh
+++ b/VERSION_2/updatenginxblocker.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 # Bash Script for Auto Updating the Nginx Bad Bot Blocker
 # Copyright - https://github.com/mitchellkrogza
-# Project Url: https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker
+# Project Url: https://github.com/mariusv/nginx-badbot-blocker
 
 # MAKE SURE you have your whitelist-ips.conf and whitelist-domains.conf files in /etc/nginx/bots.d
-# A major change to using include files was introduced in
-# https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/commit/c7acdfa8228d2f19a83e5bb14d54355db86fcebf
-
 # PLEASE READ UPDATED CONFIGURATION INSTRUCTIONS BEFORE USING THIS
 
 # Save this file as /bin/updatenginxblocker.sh
@@ -17,7 +14,7 @@
 # Place your own valid email address where it says "me@myemail.com"
  
 cd /etc/nginx/conf.d
-sudo wget https://raw.githubusercontent.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/master/conf.d/globalblacklist.conf -O globalblacklist.conf
+sudo wget https://github.com/mariusv/nginx-badbot-blocker/raw/master/VERSION_2/conf.d/blacklist.conf -O blacklist.conf
 sudo service nginx reload | mail -s "Nginx Bad Bot Blocker Updated" me@myemail.com
 exit 0
 


### PR DESCRIPTION
Simple and safe auto updating of the bot blocker through a bash script controlled with cron.
Have had this running safely on 3 Nginx servers pulling their updates automatically from my repo every day, works perfectly.