### PR TITLE
Referer Word (-)

### DIFF
--- a/VERSION_2/conf.d/blacklist.conf
+++ b/VERSION_2/conf.d/blacklist.conf
@@ -21,11 +21,11 @@
 ### bringing to all existing users a new super powerful version of the bot blocker which is much easier to maintain and also to update. 
 
 ### Last Updated
-### Thu Mar 16 09:11:39 SAST 2017
+### Thu Mar 16 11:01:30 SAST 2017
 ### End Last Updated
 
 ### Generated in
-### 0.20169878006 seconds
+### 0.220401525497 seconds
 ### End Generated in
 
 ### Tested on: nginx/1.10.0 (Ubuntu 16.04)
@@ -766,7 +766,6 @@ map $http_referer $bad_words {
 	"~*gaysex"		1;
 	"~*getamateurs"		1;
 	"~*glucophage"		1;
-	"~*hardcore"		1;
 	"~*holdem"		1;
 	"~*hold-em"		1;
 	"~*hydrochlorothiazide"		1;


### PR DESCRIPTION
The word "hardcore" removed from list of bad referrers words. The word can be used not only in a bad way but also good and legitimate ways too. Had a user who picked up problems on his own legitimate site who had a post with the word hardcore in it and it was causing his own pages not to load. 