### PR TITLE
Remove blocking in internal network ranges.

### DIFF
--- a/VERSION_2/conf.d/blacklist.conf
+++ b/VERSION_2/conf.d/blacklist.conf
@@ -21,11 +21,11 @@
 ### bringing to all existing users a new super powerful version of the bot blocker which is much easier to maintain and also to update. 
 
 ### Last Updated
-### Thu Mar 16 11:01:30 SAST 2017
+### Fri Mar 17 07:55:55 SAST 2017
 ### End Last Updated
 
 ### Generated in
-### 0.220401525497 seconds
+### 0.205321550369 seconds
 ### End Generated in
 
 ### Tested on: nginx/1.10.0 (Ubuntu 16.04)
@@ -4638,7 +4638,6 @@ geo $validate_client {
 # hampering down Nginx with all the checks against perma-banned IP's
 
 # START BAD IP RANGES ### DO NOT EDIT THIS LINE AT ALL ###
-	10.0.0.0/8		1;
 	104.223.37.150		1;
 	104.5.92.27		1;
 	109.236.83.247		1;
@@ -4697,7 +4696,6 @@ geo $validate_client {
 	188.209.52.101		1;
 	190.152.223.27		1;
 	191.96.249.29		1;
-	192.168.0.0/16		1;
 	192.69.89.173		1;
 	193.201.224.205		1;
 	195.154.183.190		1;


### PR DESCRIPTION
As per https://github.com/mariusv/nginx-badbot-blocker/issues/92 

Subnets removed from Blocking:
10.0.0.0/8
192.168.0.0/16

Affects people's internal network structures being blocked which is not the aim of what we want this to block.

172.16.0.0/12 also removed earlier this week due to report by user of https://github.com/mitchellkrogza/apache-ultimate-bad-bot-blocker/issues/7